### PR TITLE
broker_use_ssl = {

### DIFF
--- a/pos_multi_store/celery.py
+++ b/pos_multi_store/celery.py
@@ -1,7 +1,13 @@
 import os
 from celery import Celery
+import ssl 
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pos_multi_store.settings")
-app = Celery("pos_multi_store")
+app = Celery("pos_multi_store", broker_use_ssl = {
+        'ssl_cert_reqs': ssl.CERT_NONE
+     },
+     redis_backend_use_ssl = {
+        'ssl_cert_reqs': ssl.CERT_NONE
+     })
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()


### PR DESCRIPTION
        'ssl_cert_reqs': ssl.CERT_NONE
     },
     redis_backend_use_ssl = {
        'ssl_cert_reqs': ssl.CERT_NONE
     }