### PR TITLE
refactor(entrypoint): split web and worker into separate services

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,10 @@ echo "=== Aplicando migraciones ==="
 python manage.py makemigrations --noinput
 python manage.py migrate --noinput
 
-echo "=== Iniciando Celery Worker ==="
-celery -A pos_multi_store worker -l info &
-
-
-echo "=== Iniciando Daphne ==="
-exec daphne -b 0.0.0.0 -p ${PORT:-8000} pos_multi_store.asgi:application
+if [ "$SERVICE_TYPE" = "worker" ]; then
+    echo "=== Iniciando Celery Worker ==="
+    exec celery -A pos_multi_store worker -l info --concurrency=4
+else
+    echo "=== Iniciando Daphne ==="
+    exec daphne -b 0.0.0.0 -p ${PORT:-8000} pos_multi_store.asgi:application
+fi


### PR DESCRIPTION
Use SERVICE_TYPE env var to run either Celery worker or Daphne, replacing the previous approach of running both in a single process.