### PR TITLE
refactor: unificar REDIS_URL y REDIS_CHANNELS_URL

### DIFF
--- a/pos_multi_store/celery.py
+++ b/pos_multi_store/celery.py
@@ -1,27 +1,23 @@
 import os
 import ssl
 from celery import Celery
+from django.conf import settings
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pos_multi_store.settings")
 
 app = Celery("pos_multi_store")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-redis_url = os.environ.get("REDIS_URL")
+redis_url = settings.REDIS_URL
 
-if redis_url:
-    app.conf.broker_url = redis_url
-    app.conf.result_backend = redis_url
-
-    if redis_url.startswith("rediss://"):
-        # Upstash uses valid SSL certificates
-        app.conf.broker_use_ssl = {
-            "ssl_cert_reqs": ssl.CERT_REQUIRED,
-            "ssl_check_hostname": True
-        }
-        app.conf.redis_backend_use_ssl = {
-            "ssl_cert_reqs": ssl.CERT_REQUIRED,
-            "ssl_check_hostname": True
-        }
+if redis_url and redis_url.startswith("rediss://"):
+    app.conf.broker_use_ssl = {
+        "ssl_cert_reqs": ssl.CERT_REQUIRED,
+        "ssl_check_hostname": True
+    }
+    app.conf.redis_backend_use_ssl = {
+        "ssl_cert_reqs": ssl.CERT_REQUIRED,
+        "ssl_check_hostname": True
+    }
 
 app.autodiscover_tasks()

--- a/pos_multi_store/settings.py
+++ b/pos_multi_store/settings.py
@@ -207,7 +207,7 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            'hosts': [config('REDIS_CHANNELS_URL')],
+            'hosts': [config('REDIS_URL')],
             'capacity': 1000,
             'expiry': 60,
             'prefix': 'ws_',


### PR DESCRIPTION
- CHANNEL_LAYERS ahora usa REDIS_URL
- celery.py lee de settings en lugar de os.environ
- Elimina variable redundante REDIS_CHANNELS_URL