### PR TITLE
fix: usar os.environ.get en celery.py para evitar AttributeError

### DIFF
--- a/pos_multi_store/celery.py
+++ b/pos_multi_store/celery.py
@@ -1,14 +1,13 @@
 import os
 import ssl
 from celery import Celery
-from django.conf import settings
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pos_multi_store.settings")
 
 app = Celery("pos_multi_store")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-redis_url = settings.REDIS_URL
+redis_url = os.environ.get("REDIS_URL")
 
 if redis_url and redis_url.startswith("rediss://"):
     app.conf.broker_use_ssl = {


### PR DESCRIPTION
- settings no está disponible al importar celery.py
- Vuelve a usar os.environ.get("REDIS_URL")