### PR TITLE
refactor: separar Redis en dos instancias para Celery y WebSockets

### DIFF
--- a/pos_multi_store/celery.py
+++ b/pos_multi_store/celery.py
@@ -7,7 +7,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pos_multi_store.settings")
 app = Celery("pos_multi_store")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-redis_url = os.environ.get("REDIS_URL")
+redis_url = os.environ.get("REDIS_CELERY_URL")
 
 if redis_url and redis_url.startswith("rediss://"):
     app.conf.broker_use_ssl = {

--- a/pos_multi_store/settings.py
+++ b/pos_multi_store/settings.py
@@ -207,16 +207,16 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            'hosts': [config('REDIS_URL')],
-            'capacity': 1000,
-            'expiry': 60,
+            'hosts': [config('REDIS_WS_URL')],
+            'capacity': 200,
+            'expiry': 30,
             'prefix': 'ws_',
         },
     },
 }
 
-CELERY_BROKER_URL = config('REDIS_URL')
-CELERY_RESULT_BACKEND = config('REDIS_URL')
+CELERY_BROKER_URL = config('REDIS_CELERY_URL')
+CELERY_RESULT_BACKEND = config('REDIS_CELERY_URL')
 
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"


### PR DESCRIPTION
- REDIS_CELERY_URL para Celery (broker + results)
- REDIS_WS_URL para Channels (WebSockets)
- Channels: capacity=200, expiry=30
- Activar optimizaciones de Celery worker