### PR TITLE
revert: restaurar configuración Redis/Celery a estado anterior a REDI…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,7 @@ python manage.py migrate --noinput
 
 if [ "$SERVICE_TYPE" = "worker" ]; then
     echo "=== Iniciando Celery Worker ==="
-    # Optimizado para Render Standard (2GB RAM, 1 CPU)
-    exec celery -A pos_multi_store worker \
-        -l info \
-        --concurrency=2 \
-        --max-memory-per-child=512000 \
-        --time-limit=1800 \
-        --soft-time-limit=1500
+    exec celery -A pos_multi_store worker -l info --concurrency=4
 else
     echo "=== Iniciando Daphne ==="
     exec daphne -b 0.0.0.0 -p ${PORT:-8000} pos_multi_store.asgi:application

--- a/pos_multi_store/celery.py
+++ b/pos_multi_store/celery.py
@@ -1,28 +1,24 @@
 import os
 import ssl
-import django
 from celery import Celery
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pos_multi_store.settings")
 
-django.setup()
-
 app = Celery("pos_multi_store")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-redis_url = os.environ.get("REDIS_CELERY_URL") or os.environ.get("REDIS_URL")
+redis_url = os.environ.get("REDIS_URL")
 
 if redis_url:
     app.conf.broker_url = redis_url
     app.conf.result_backend = redis_url
 
     if redis_url.startswith("rediss://"):
-        ssl_config = {
-            "ssl_cert_reqs": ssl.CERT_NONE,
-            "ssl_check_hostname": False,
+        app.conf.broker_use_ssl = {
+            "ssl_cert_reqs": ssl.CERT_NONE
         }
-
-        app.conf.broker_use_ssl = ssl_config
-        app.conf.redis_backend_use_ssl = ssl_config
+        app.conf.redis_backend_use_ssl = {
+            "ssl_cert_reqs": ssl.CERT_NONE
+        }
 
 app.autodiscover_tasks()

--- a/pos_multi_store/settings.py
+++ b/pos_multi_store/settings.py
@@ -207,7 +207,7 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            'hosts': [config('REDIS_WS_URL', default=config('REDIS_CHANNELS_URL', default=config('REDIS_URL')))],
+            'hosts': [config('REDIS_URL')],
             'capacity': 1000,
             'expiry': 60,
             'prefix': 'ws_',
@@ -215,8 +215,8 @@ CHANNEL_LAYERS = {
     },
 }
 
-CELERY_BROKER_URL = config('REDIS_CELERY_URL', default=config('REDIS_URL'))
-CELERY_RESULT_BACKEND = config('REDIS_CELERY_URL', default=config('REDIS_URL'))
+CELERY_BROKER_URL = config('REDIS_URL')
+CELERY_RESULT_BACKEND = config('REDIS_URL')
 
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"


### PR DESCRIPTION
…S_CHANNELS_URL

- entrypoint.sh: restaurar a --concurrency=4 sin límites de memoria/tiempo
- celery.py: usar REDIS_URL directamente con ssl.CERT_NONE
- settings.py: CHANNEL_LAYERS usa REDIS_URL en lugar de REDIS_CHANNELS_URL