### PR TITLE
fix: auto-delete duplicate manual inventory logs

### DIFF
--- a/logs/tasks.py
+++ b/logs/tasks.py
@@ -32,16 +32,18 @@ def get_logs_duplicates_or_inconsistens_task(self, store_ids, start_date, end_da
 
         # 🚀 Usar iterator() evita cargar todo en memoria
         for i, log in enumerate(logs_qs.iterator(), start=1):
+            # Detectar entrada manual duplicada con stock igual al previo
+            if not log.is_consistent() and log.movement == "MA":
+                previous_obj = StoreProductLog.objects.filter(
+                    store_product=log.store_product, pk__lt=log.pk
+                ).order_by("-pk").first()
+                if previous_obj and log.updated_stock == previous_obj.updated_stock:
+                    log.delete()
+                    continue
+            
             # Si estos métodos hacen queries, puede optimizarse más (ver nota abajo)
             if log.is_repeated() or not log.is_consistent() or log.has_negatives():
                 ids.append(log.id)
-                # Print si es entrada manual con stock igual al previo
-                if not log.is_consistent() and log.movement == "MA":
-                    previous_obj = StoreProductLog.objects.filter(
-                        store_product=log.store_product, pk__lt=log.pk
-                    ).order_by("-pk").first()
-                    if previous_obj and log.updated_stock == previous_obj.updated_stock:
-                        print(f"⚠️ Log duplicado detectado - Producto: {log.store_product.product.name}, Tienda: {log.store_product.store.get_full_name()}")
 
             if i % update_every == 0 or i == total:
                 percent = max(int((i / total) * 99), 1)


### PR DESCRIPTION
- Remove duplicate manual logs (MA movement) where updated_stock equals previous log's updated_stock
- Deleted logs are not included in audit results
- Prevents inconsistent logs from being reported