### PR TITLE
fix: auto-correct inconsistent manual inventory logs

### DIFF
--- a/logs/tasks.py
+++ b/logs/tasks.py
@@ -32,13 +32,22 @@ def get_logs_duplicates_or_inconsistens_task(self, store_ids, start_date, end_da
 
         # 🚀 Usar iterator() evita cargar todo en memoria
         for i, log in enumerate(logs_qs.iterator(), start=1):
-            # Detectar entrada manual duplicada con stock igual al previo
+            # Detectar entrada manual inconsistente
             if not log.is_consistent() and log.movement == "MA":
                 previous_obj = StoreProductLog.objects.filter(
                     store_product=log.store_product, pk__lt=log.pk
                 ).order_by("-pk").first()
-                if previous_obj and log.updated_stock == previous_obj.updated_stock:
-                    log.delete()
+                if previous_obj:
+                    # Si stock actualizado es igual al anterior, es duplicado - eliminar
+                    if log.updated_stock == previous_obj.updated_stock:
+                        log.delete()
+                        continue
+                    # Si no, ajustar previous_stock al updated_stock del log anterior
+                    log.previous_stock = previous_obj.updated_stock
+                    # Si entrada manual pero stock disminuye, cambiar a ajuste
+                    if log.previous_stock > log.updated_stock:
+                        log.action = "A"  # Ajuste
+                    log.save(update_fields=['previous_stock', 'action'])
                     continue
             
             # Si estos métodos hacen queries, puede optimizarse más (ver nota abajo)


### PR DESCRIPTION
- Detect manual logs (MA) with inconsistent previous_stock and auto-adjust to match previous log's updated_stock
- Delete duplicate manual logs where updated_stock equals previous log's updated_stock
- Convert manual entries (action E) to adjustments (action A) when stock decreases
- Prevents invalid manual entries from being reported as inconsistencies