### PR TITLE
feat(audit): mark inconsistent StoreProducts for stock verification

### DIFF
--- a/logs/tasks.py
+++ b/logs/tasks.py
@@ -33,22 +33,22 @@ def get_logs_duplicates_or_inconsistens_task(self, store_ids, start_date, end_da
         # 🚀 Usar iterator() evita cargar todo en memoria
         for i, log in enumerate(logs_qs.iterator(), start=1):
             # Detectar entrada manual inconsistente
-            if not log.is_consistent() and log.movement == "MA":
-                previous_obj = StoreProductLog.objects.filter(
-                    store_product=log.store_product, pk__lt=log.pk
-                ).order_by("-pk").first()
-                if previous_obj:
-                    # Si stock actualizado es igual al anterior, es duplicado - eliminar
-                    if log.updated_stock == previous_obj.updated_stock:
-                        log.delete()
-                        continue
-                    # Si no, ajustar previous_stock al updated_stock del log anterior
-                    log.previous_stock = previous_obj.updated_stock
-                    # Si entrada manual pero stock disminuye, cambiar a ajuste
-                    if log.previous_stock > log.updated_stock:
-                        log.action = "A"  # Ajuste
-                    log.save(update_fields=['previous_stock', 'action'])
-                    continue
+#            if not log.is_consistent() and log.movement == "MA":
+#                previous_obj = StoreProductLog.objects.filter(
+#                    store_product=log.store_product, pk__lt=log.pk
+#                ).order_by("-pk").first()
+#                if previous_obj:
+#                    # Si stock actualizado es igual al anterior, es duplicado - eliminar
+#                    if log.updated_stock == previous_obj.updated_stock:
+#                        log.delete()
+#                        continue
+#                    # Si no, ajustar previous_stock al updated_stock del log anterior
+#                    log.previous_stock = previous_obj.updated_stock
+#                    # Si entrada manual pero stock disminuye, cambiar a ajuste
+#                    if log.previous_stock > log.updated_stock:
+#                        log.action = "A"  # Ajuste
+#                    log.save(update_fields=['previous_stock', 'action'])
+#                    continue
             
             # Si estos métodos hacen queries, puede optimizarse más (ver nota abajo)
             if log.is_repeated() or not log.is_consistent() or log.has_negatives():
@@ -122,7 +122,7 @@ def get_store_products_inconsistens_task(self, store_ids):
 
         # Filtrar productos inconsistentes
         store_products_inconsistents = StoreProduct.objects.filter(id__in=ids)
-
+        store_products_inconsistents.update(requires_stock_verification=True)
         serializer = StoreProductAuditSerializer(store_products_inconsistents, many=True)
 
         # Estado final

--- a/products/views.py
+++ b/products/views.py
@@ -1443,6 +1443,6 @@ class StockVerificationDashboardView(APIView):
     def get(self, request):
         from .tasks import get_stock_verification_dashboard
         tenant = request.user.get_tenant()
-        store_ids = list(Store.objects.filter(tenant=tenant, store_type="T").values_list("id", flat=True))
+        store_ids = list(Store.objects.filter(tenant=tenant).values_list("id", flat=True))
         task = get_stock_verification_dashboard.delay(store_ids)
         return Response({"task": task.id})


### PR DESCRIPTION
Flag requires_stock_verification=True on StoreProducts detected as inconsistent during audit. Disable auto-correction of manual entry logs. Include all stores (not just type T) in verification dashboard.