### PR TITLE
fix(tenants): eliminar save_payment_method del payload de pago MP

### DIFF
--- a/tenants/views.py
+++ b/tenants/views.py
@@ -238,7 +238,6 @@ class CreateSubscriptionView(APIView):
             "payment_method_id": payment_method_id,
             "payer": {"email": payer_email},
             "description": f"Pago plan: {plan.name}",
-            "save_payment_method": True,
         }
 
         headers = {


### PR DESCRIPTION
Parámetro no válido en /v1/payments que causaba error 400.