### PR TITLE
fix(tenants): agregar X-Idempotency-Key en pago MP

### DIFF
--- a/tenants/views.py
+++ b/tenants/views.py
@@ -243,6 +243,7 @@ class CreateSubscriptionView(APIView):
         headers = {
             "Authorization": f"Bearer {mp_access_token}",
             "Content-Type": "application/json",
+            "X-Idempotency-Key": f"{tenant.short_name}_{plan_id}_{card_token}",
         }
 
         logger.info(f"[CreateSubscription] payment payload: {payment_payload}")


### PR DESCRIPTION
Header requerido por MercadoPago en /v1/payments para prevenir cobros duplicados.